### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/signalbox/tests/test_allocation.py
+++ b/signalbox/tests/test_allocation.py
@@ -48,7 +48,7 @@ class Test_Allocation(TestCase):
     def test_allocation(self):
         """Simulate studies and check we have sane allocation ratios at N=30."""
 
-    def test_allocation(self):
+    def test_allocation_two(self):
         study = Study.objects.get(slug='test-allocation-study')
         study.auto_randomise = False
         # note - we just test this, because it uses weighted_ranomisation too


### PR DESCRIPTION
Fixes #6.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

